### PR TITLE
Vote for a new repo: dflow 101

### DIFF
--- a/votes/deepmodeling-activity.md
+++ b/votes/deepmodeling-activity.md
@@ -22,6 +22,7 @@ TOC members
 
 ## Result
 
+Approved by HanWang.
 
 
 See also https://github.com/deepmodeling/community/pull/13 .

--- a/votes/new_repo_dflow101_vote.md
+++ b/votes/new_repo_dflow101_vote.md
@@ -1,0 +1,21 @@
+# A Vote for New Repo: dflow101
+
+## Proposal
+
+[Dflow](https://github.com/deepmodeling/dflow) is a Python framework for constructing scientific computing workflows (e.g. concurrent learning workflows) employing Argo Workflows as the workflow engine.
+
+After first release of dflow, there already have some dflow projects. In order to show all dflow projects and make dflow more popular, I suggest to make a new repo "dflow101".
+
+Most dflow101 projects are not stored in this repo, however, this repo maintain links to each projects.
+
+## Deadline
+
+The vote will be open for at least 6 days unless there is an objection.
+
+## Scope
+
+TOC MEMBERS.
+
+## Result
+
+See also https://github.com/deepmodeling/community/pull/.


### PR DESCRIPTION
After first release of dflow, there already have some dflow projects. In order to show all dflow projects and make dflow more popular, I suggest to make a new repo "dflow101".

Most dflow101 projects are not stored in this repo, however, this repo maintain links to each projects.