### PR TITLE
A vote for community Logo: DMFF

### DIFF
--- a/votes/DMFF_logo_vote.md
+++ b/votes/DMFF_logo_vote.md
@@ -4,6 +4,8 @@
 It has been nearly half a year since the official release of DMFF. As a Jax-based python package, DMFF provides a fully differentiable implementation of molecular force field models. We have designed a logo for DMFF. Here is the latest version of it. Please determine whether you agree to use it. 
 
 ![DMFF logo](https://dp-public.oss-cn-beijing.aliyuncs.com/community/logo/DMFF.jpg)
+
+The SVG format is here: https://dp-public.oss-cn-beijing.aliyuncs.com/community/logo/DMFF.svg
   
 ## Deadline
 The vote will be open for at least 7 days unless there is an objection.

--- a/votes/DMFF_logo_vote.md
+++ b/votes/DMFF_logo_vote.md
@@ -12,3 +12,6 @@ The vote will be open for at least 7 days unless there is an objection.
 
 ## Scope
 TOC MEMBERS and MD TEAM MAINTAINERS
+
+## Result:
+Proved by Kuang Yu

--- a/votes/DMFF_logo_vote.md
+++ b/votes/DMFF_logo_vote.md
@@ -1,0 +1,12 @@
+# A vote for community Logo: DMFF
+ 
+## Proposal
+It has been nearly half a year since the official release of DMFF. As a Jax-based python package, DMFF provides a fully differentiable implementation of molecular force field models. We have designed a logo for DMFF. Here is the latest version of it. Please determine whether you agree to use it. 
+
+![DMFF logo](https://dp-public.oss-cn-beijing.aliyuncs.com/community/logo/DMFF.jpg)
+  
+## Deadline
+The vote will be open for at least 7 days unless there is an objection.
+
+## Scope
+TOC MEMBERS and MD TEAM MAINTAINERS


### PR DESCRIPTION
It has been nearly half a year since the official release of DMFF. As a Jax-based python package, DMFF provides a fully differentiable implementation of molecular force field models. We have designed a logo for DMFF. Here is the latest version of it. Please determine whether you agree to use it. 

![DMFF logo](https://dp-public.oss-cn-beijing.aliyuncs.com/community/logo/DMFF.jpg)