### PR TITLE
Create CrystalFormer_vote.md

### DIFF
--- a/votes/CrystalFormer_vote.md
+++ b/votes/CrystalFormer_vote.md
@@ -1,0 +1,16 @@
+# A Vote for New Projects:  CrystalFormer
+
+## Proposal
+
+_CrystalFormer_ is a transformer-based autoregressive model specifically designed for space group-controlled generation of crystalline materials. The space group symmetry significantly simplifies the
+crystal space, which is crucial for data and compute efficient generative modeling of crystalline materials.
+
+For more information, see the [original repository](https://github.com/zdcao121/CrystalFormer)
+
+## Deadline
+
+The vote will be open for at least 6 days unless there is an objection.
+
+## Scope
+
+TOC MEMBERS.

--- a/votes/CrystalFormer_vote.md
+++ b/votes/CrystalFormer_vote.md
@@ -9,7 +9,7 @@ For more information, see the [original repository](https://github.com/zdcao121/
 
 ## Deadline
 
-The vote will be open for at least 6 days unless there is an objection.
+This vote is rather urgent as the corresponding paper is about to be published. Therefore, once all TOC members agree, we will pass it through voting.
 
 ## Scope
 


### PR DESCRIPTION
This is a vote for CrystalFormer. _CrystalFormer_ is a transformer-based autoregressive model specifically designed for space group-controlled generation of crystalline materials. The space group symmetry significantly simplifies the crystal space, which is crucial for data and compute efficient generative modeling of crystalline materials.

For more information, see the [original repository](https://github.com/zdcao121/CrystalFormer)