### PR TITLE
Create TOC_Supplementary rule_vote.md

### DIFF
--- a/votes/TOC_Supplementary rule_vote.md
+++ b/votes/TOC_Supplementary rule_vote.md
@@ -1,0 +1,15 @@
+# A Vote for a supplementary rule of TOC
+
+## Proposal
+In order to improve the efficiency of feedback on TOC voting results, it is hoped to add the following supplementary clauses to the current **toc-README-Decision Making-Approvals-Lazy Consensus**.
+
+Supplementary rule: *During the voting period, if all TOC members actively cast a +1, the voting process can be ended early and the resolution can be passed.*
+
+
+## Deadline
+
+The vote will be open for at least 6 days unless there is an objection.
+
+## Scope
+
+TOC MEMBERS.


### PR DESCRIPTION
# A Vote for a supplementary rule of TOC

## Proposal
In order to improve the efficiency of feedback on TOC voting results, the following supplementary provisions have been added to the current **toc-README-Decision Making-Approvals-Lazy Consensus**.

Supplementary rule: *During the voting period, if all TOC members actively cast a +1, the voting process can be ended early and the resolution can be passed.*


## Deadline

The vote will be open for at least 6 days unless there is an objection.

## Scope

TOC MEMBERS.